### PR TITLE
Quick nav for Examples page

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,8 @@
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.12.0",
         "postcss": "^8.4.49",
+        "prettier": "^3.4.1",
+        "prettier-plugin-tailwindcss": "^0.6.9",
         "tailwindcss": "^3.4.15",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.15.0",
@@ -3451,6 +3453,101 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.9.tgz",
+      "integrity": "sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig-melody": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig-melody": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/prism-react-renderer": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
     "postcss": "^8.4.49",
+    "prettier": "^3.4.1",
+    "prettier-plugin-tailwindcss": "^0.6.9",
     "tailwindcss": "^3.4.15",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",

--- a/prettier.config.ts
+++ b/prettier.config.ts
@@ -1,0 +1,9 @@
+/** @type {import('prettier').Config} */
+export default {
+  semi: false,
+  singleQuote: true,
+  trailingComma: "all",
+  pluginSearchDirs: false,
+  plugins: ["@ianvs/prettier-plugin-sort-imports"],
+  importOrder: ["^@", "^[a-zA-Z0-9-]+", "^[./]"],
+};

--- a/src/components/BottomNavigation.tsx
+++ b/src/components/BottomNavigation.tsx
@@ -9,11 +9,11 @@ const BottomNavigation = ({
   frontLink?: string;
 }) => {
   return (
-    <div className="flex items-center justify-between lg:justify-around py-7">
+    <div className="flex items-center justify-between py-7 lg:justify-around">
       <div className="font-bold underline">
         <Link
           to={`/${backLink}`}
-          className="font-bold underline flex flex-col items-start text-gray-900"
+          className="flex flex-col items-start font-bold text-gray-900 underline"
         >
           {backLink && (
             <>
@@ -26,7 +26,7 @@ const BottomNavigation = ({
       <div>
         <Link
           to={`/${frontLink}`}
-          className="font-bold underline flex flex-col items-end text-gray-900"
+          className="flex flex-col items-end font-bold text-gray-900 underline"
         >
           {frontLink && (
             <>

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -31,7 +31,7 @@ const CodeBlock = ({
     <div className="relative">
       <button
         onClick={copyToClipboard}
-        className="absolute top-2 right-2 p-1 bg-blue-500 text-white rounded text-xs"
+        className="absolute right-2 top-2 rounded bg-blue-500 p-1 text-xs text-white"
       >
         {buttonText}
       </button>
@@ -41,7 +41,7 @@ const CodeBlock = ({
         language={language}
       >
         {({ tokens, getLineProps, getTokenProps }) => (
-          <pre className="overflow-x-auto rounded-lg p-4 bg-[#011627]">
+          <pre className="overflow-x-auto rounded-lg bg-[#011627] p-4">
             {tokens.map((line, i) => (
               <div
                 key={i}
@@ -49,7 +49,7 @@ const CodeBlock = ({
                 className="table-row"
               >
                 {showLineNumbers && (
-                  <span className="table-cell text-right pr-4 select-none opacity-50 text-white">
+                  <span className="table-cell select-none pr-4 text-right text-white opacity-50">
                     {i + 1}
                   </span>
                 )}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Footer: React.FC = () => {
   return (
-    <div className="z-[999] w-screen bg-gray-800 text-white text-center py-4">
+    <div className="z-[999] w-screen bg-gray-800 py-4 text-center text-white">
       Developed with 💖 by{" "}
       <a href="https://nsengixp.onrender.com/" className="underline">
         Eliezer Nsengi

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,12 +4,12 @@ import Footer from "./Footer";
 
 const Layout = () => {
   return (
-    <div className="flex flex-col min-h-screen overflow-x-hidden">
-      <div className="flex flex-grow flex-col lg:flex-row  ">
-        <aside className="lg:fixed lg:h-[100vh] w-full lg:w-64 bg-gray-200 border-b md:border-r border-gray-200 p-6 md:border-b-0">
+    <div className="flex min-h-screen flex-col overflow-x-hidden">
+      <div className="flex flex-grow flex-col lg:flex-row">
+        <aside className="w-full border-b border-gray-200 bg-gray-200 p-6 md:border-b-0 md:border-r lg:fixed lg:h-[100vh] lg:w-64">
           <Navigation />
         </aside>
-        <main className="flex-1 lg:ml-[15vw] 2xl:ml-auto  p-4 md:p-8 overflow-y-auto">
+        <main className="overflow-y-auto lg:ml-64">
           <Outlet />
         </main>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,40 +3,40 @@ import { Link, NavLink } from "react-router-dom";
 
 const Navigation = () => {
   return (
-    <nav className="flex items-center justify-center lg:overflow-hidden lg:flex-col lg:space-y-4 w-screen -ml-5 lg:ml lg:w-full">
+    <nav className="lg:ml -ml-5 flex w-screen items-center justify-center lg:w-full lg:flex-col lg:space-y-4 lg:overflow-hidden">
       <img
-        className="h-10 w-10 hidden md:block scale-125 lg:mb-10 lg:mt-5 lg:h-20 lg:w-20"
+        className="hidden h-10 w-10 scale-125 md:block lg:mb-10 lg:mt-5 lg:h-20 lg:w-20"
         src="/regex-craft-logo.png"
         alt="Regex Craft Logo"
       />
       <NavLink
         to="/"
-        className="px-1 md:px-4 py-2 rounded-md hover:bg-gray-200"
+        className="rounded-md px-1 py-2 hover:bg-gray-200 md:px-4"
       >
         Home
       </NavLink>
       <NavLink
         to="/examples"
-        className="px-1 md:px-4 py-2 rounded-md hover:bg-gray-200"
+        className="rounded-md px-1 py-2 hover:bg-gray-200 md:px-4"
       >
         Examples
       </NavLink>
       <NavLink
         to="/playground"
-        className="px-1 md:px-4 py-2 rounded-md hover:bg-gray-200"
+        className="rounded-md px-1 py-2 hover:bg-gray-200 md:px-4"
       >
         Playground
       </NavLink>
 
       <NavLink
         to="/about"
-        className="px-1 md:px-4 py-2 rounded-md hover:bg-gray-200"
+        className="rounded-md px-1 py-2 hover:bg-gray-200 md:px-4"
       >
         About
       </NavLink>
       <Link
         to="https://github.com/iAmNsengi/regexcraft"
-        className="px-4 py-2 rounded-md hover:bg-gray-200"
+        className="rounded-md px-4 py-2 hover:bg-gray-200"
       >
         GitHub
       </Link>

--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -52,12 +52,12 @@ const Playground = () => {
 
   return (
     <>
-      <div className="max-w-4xl mx-auto">
-        <h1 className="text-3xl font-bold mb-8">RegexCraft Playground</h1>
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-8 text-3xl font-bold">RegexCraft Playground</h1>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
           <div>
-            <h2 className="text-xl font-semibold mb-4">Validation Rules</h2>
+            <h2 className="mb-4 text-xl font-semibold">Validation Rules</h2>
             <div className="space-y-2">
               {[
                 "email",
@@ -81,7 +81,7 @@ const Playground = () => {
                         setValidationRules([...validationRules, rule]);
                       } else {
                         setValidationRules(
-                          validationRules.filter((r) => r !== rule)
+                          validationRules.filter((r) => r !== rule),
                         );
                       }
                     }}
@@ -92,19 +92,19 @@ const Playground = () => {
             </div>
 
             <div className="mt-6">
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="mb-2 block text-sm font-medium text-gray-700">
                 Test Input
               </label>
               <input
                 type="text"
-                className="w-full px-4 py-2 border rounded-md"
+                className="w-full rounded-md border px-4 py-2"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
               />
             </div>
 
             <button
-              className="mt-4 px-4 py-2 bg-primary text-white rounded-md hover:bg-primary/90"
+              className="mt-4 rounded-md bg-primary px-4 py-2 text-white hover:bg-primary/90"
               onClick={validateInput}
             >
               Test
@@ -112,21 +112,21 @@ const Playground = () => {
           </div>
 
           <div>
-            <h2 className="text-xl font-semibold mb-4">Results</h2>
+            <h2 className="mb-4 text-xl font-semibold">Results</h2>
             {result && (
               <div className="space-y-4">
-                <div className="p-4 rounded-md bg-gray-50">
+                <div className="rounded-md bg-gray-50 p-4">
                   <p className="font-medium">
                     Valid: {result.isValid ? "✅" : "❌"}
                   </p>
                   {result.failedRequirements.length > 0 && (
                     <div className="mt-2">
                       <p className="font-medium">Failed Requirements:</p>
-                      <ul className="list-disc list-inside text-red-600">
+                      <ul className="list-inside list-disc text-red-600">
                         {result.failedRequirements.map(
                           (req: string, i: number) => (
                             <li key={i}>{req}</li>
-                          )
+                          ),
                         )}
                       </ul>
                     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.aside::-webkit-scrollbar {
+  display: none; /* Hides the scrollbar for Webkit-based browsers */
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-.aside::-webkit-scrollbar {
+.hide-scrollbar::-webkit-scrollbar {
   display: none; /* Hides the scrollbar for Webkit-based browsers */
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -4,16 +4,16 @@ const About = () => {
   return (
     <>
       <HelmetWrapper title="About" />
-      <div className="max-w-4xl mx-auto p-6">
-        <h1 className="text-4xl font-bold mb-6">About RegexCraft</h1>
-        <p className="text-lg text-gray-600 mb-4">
+      <div className="mx-auto max-w-4xl p-6">
+        <h1 className="mb-6 text-4xl font-bold">About RegexCraft</h1>
+        <p className="mb-4 text-lg text-gray-600">
           RegexCraft is a powerful utility class designed to simplify the
           process of building and managing regular expressions. With its fluent,
           chainable API, developers can easily create complex regex patterns
           without the hassle of manual string manipulation.
         </p>
-        <h2 className="text-2xl font-semibold mt-8 mb-4">Meet the Developer</h2>
-        <p className="text-lg text-gray-600 mb-4">
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">Meet the Developer</h2>
+        <p className="mb-4 text-lg text-gray-600">
           Developed by{" "}
           <a
             href="https://nsengixp.onrender.com/"
@@ -25,10 +25,10 @@ const About = () => {
           validation and testing. Eliezer is passionate about creating tools
           that enhance developer productivity and streamline workflows.
         </p>
-        <h2 className="text-2xl font-semibold mt-8 mb-4">
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">
           Why Use RegexCraft?
         </h2>
-        <ul className="list-disc list-inside text-gray-600">
+        <ul className="list-inside list-disc text-gray-600">
           <li>
             🔍 **Easy to Use**: Build complex regex patterns with a simple,
             chainable API.
@@ -46,8 +46,8 @@ const About = () => {
             examples to help you get started quickly.
           </li>
         </ul>
-        <h2 className="text-2xl font-semibold mt-8 mb-4">Get Started</h2>
-        <p className="text-lg text-gray-600 mb-4">
+        <h2 className="mb-4 mt-8 text-2xl font-semibold">Get Started</h2>
+        <p className="mb-4 text-lg text-gray-600">
           Whether you're a beginner or an experienced developer, RegexCraft is
           here to help you manage your regular expressions with ease. Check out
           the{" "}

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -337,25 +337,43 @@ console.log(result); // { value: 'Password1!', isValid: true, failedRequirements
 
 const Examples = () => {
   return (
-    <>
-      <HelmetWrapper title="How To Use" />
-      <div className="max-w-4xl mx-auto">
-        <h1 className="text-3xl font-bold mb-8">Usage Examples</h1>
-        <div className="space-y-12">
-          {examples.map((example, index) => (
-            <div
-              key={index}
-              className="border rounded-lg p-6 bg-white shadow-md"
-            >
-              <h2 className="text-xl font-semibold mb-2">{example.title}</h2>
-              <p className="text-gray-600 mb-4">{example.description}</p>
-              <CodeBlock code={example.code} />
-            </div>
-          ))}
+    <div className="flex">
+      <div className="p-4 md:p-8">
+        <HelmetWrapper title="How To Use" />
+        <div className="mx-auto max-w-4xl">
+          <h1 className="mb-8 text-3xl font-bold">Usage Examples</h1>
+          <div className="space-y-12">
+            {examples.map((example, index) => (
+              <div
+                key={index}
+                id={example.title.toLowerCase().replace(/\s+/g, "-")}
+                className="rounded-lg border bg-white p-6 shadow-md"
+              >
+                <h2 className="mb-2 text-xl font-semibold">{example.title}</h2>
+                <p className="mb-4 text-gray-600">{example.description}</p>
+                <CodeBlock code={example.code} />
+              </div>
+            ))}
+          </div>
         </div>
+        <BottomNavigation backLink="home" frontLink="playground" />
       </div>
-      <BottomNavigation backLink="home" frontLink="playground" />
-    </>
+      <aside className="hide-scrollbar hidden lg:fixed lg:right-0 lg:block lg:h-[100vh] lg:w-80 lg:overflow-y-auto lg:px-6 lg:py-16">
+        <ul>
+          <h1 className="mb-5 text-2xl font-semibold">Quick nav</h1>
+          {examples.map((example) => (
+            <li key={example.title} className="mb-4">
+              <a
+                href={`#${example.title.toLowerCase().replace(/\s+/g, "-")}`}
+                className="hover:text-blue-500 hover:underline"
+              >
+                {example.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </aside>
+    </div>
   );
 };
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,15 +5,15 @@ import BottomNavigation from "../components/BottomNavigation";
 const Home = () => {
   return (
     <>
-      <div className="max-w-4xl mx-auto p-6">
-        <h1 className="text-4xl font-bold mb-4">Welcome to RegexCraft 🛠️</h1>
-        <p className="text-lg text-gray-700 mb-6">
+      <div className="mx-auto max-w-4xl p-6">
+        <h1 className="mb-4 text-4xl font-bold">Welcome to RegexCraft 🛠️</h1>
+        <p className="mb-6 text-lg text-gray-700">
           RegexCraft is a powerful utility class for building and managing
           regular expressions with a fluent, chainable API.
         </p>
 
-        <h2 className="text-2xl font-semibold mb-4">Features</h2>
-        <ul className="list-disc list-inside mb-6">
+        <h2 className="mb-4 text-2xl font-semibold">Features</h2>
+        <ul className="mb-6 list-inside list-disc">
           <li>🔗 Chainable API for building complex patterns</li>
           <li>📝 Built-in validation presets for common use cases</li>
           <li>🎯 Custom error messages for each validation rule</li>
@@ -26,7 +26,7 @@ const Home = () => {
           <li>🛠️ Easy integration with forms and validation libraries</li>
         </ul>
 
-        <h2 className="text-2xl font-semibold mb-4">Installation</h2>
+        <h2 className="mb-4 text-2xl font-semibold">Installation</h2>
         <p className="mb-4">
           To install RegexCraft, you can use npm or yarn. Run one of the
           following commands in your project directory:
@@ -35,7 +35,7 @@ const Home = () => {
         <p className="py-2">or if you use yarn:</p>
         <CodeBlock code={`yarn add regexcraft`} language="bash" />
 
-        <h2 className="text-2xl font-semibold mb-4 py-4">Getting Started</h2>
+        <h2 className="mb-4 py-4 text-2xl font-semibold">Getting Started</h2>
         <p className="mb-4">
           After installation, you can start using RegexCraft in your project.
           Here’s a quick example:
@@ -55,7 +55,7 @@ console.log(validator); // { value: 'MyPassword1!', isValid: true, failedRequire
           language="typescript"
         />
 
-        <h2 className="text-2xl font-semibold mb-4 py-4">
+        <h2 className="mb-4 py-4 text-2xl font-semibold">
           Building Your Regex
         </h2>
         <p className="mb-4">
@@ -78,7 +78,7 @@ console.log(customRegex);
 `}
           language="typescript"
         />
-        <h2 className="text-2xl font-semibold mb-4 py-2">Learn More</h2>
+        <h2 className="mb-4 py-2 text-2xl font-semibold">Learn More</h2>
         <p>
           Explore the{" "}
           <Link to="/examples" className="text-blue-500 underline">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -4,12 +4,12 @@ const NotFound = () => {
   return (
     <>
       <HelmetWrapper title="Not Found" />
-      <div className="flex flex-col items-center justify-center h-screen">
+      <div className="flex h-screen flex-col items-center justify-center">
         <h1 className="text-6xl text-red-600">404 - Page Not Found</h1>
-        <p className="text-2xl mt-4">
+        <p className="mt-4 text-2xl">
           Sorry, the page you are looking for does not exist.
         </p>
-        <a href="/" className="text-xl text-blue-500 mt-6 hover:underline">
+        <a href="/" className="mt-6 text-xl text-blue-500 hover:underline">
           Go to Home
         </a>
       </div>


### PR DESCRIPTION
- Implement a quick aside nav for examples page to easily navigate through examples
- Install and configure prettier as a dev dependency for organizing tailwind utility classes
- Re-order tailwind utility classes according to the [official tailwind recommended order of utility classes](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted)
- Add a custom class to hide scrollbars (in progress)
- Make it responsive (in progress)